### PR TITLE
[FEATURE] Add regional defaults to GTM consent config PRS-717

### DIFF
--- a/block/src/gtm-init.ts
+++ b/block/src/gtm-init.ts
@@ -2,22 +2,89 @@ import { getTrackingPrefs } from './utils';
 import { convertPrefsToGTMOpts } from './utils';
 import type { GTMConsentOptions } from './utils';
 
-const defaultConsentOpts: GTMConsentOptions = {
+const GDPRRegions = [
+  // European Member countries
+  'AT', // Austria
+  'BE', // Belgium
+  'BG', // Bulgaria
+  'CY', // Cyprus
+  'CZ', // Czech Republic
+  'DE', // Germany
+  'DK', // Denmark
+  'EE', // Estonia
+  'ES', // Spain
+  'FI', // Finland
+  'FR', // France
+  'GR', // Greece
+  'HR', // Croatia
+  'HU', // Hungary
+  'IE', // Ireland
+  'IT', // Italy
+  'LT', // Lithuania
+  'LU', // Luxembourg
+  'LV', // Latvia
+  'MT', // Malta
+  'NL', // Netherlands
+  'PL', // Poland
+  'PT', // Portugal
+  'RO', // Romania
+  'SE', // Sweden
+  'SI', // Slovenia
+  'SK', // Slovakia
+  'GB', // United Kingdom
+  // Single Market Countries that GDPR applies to
+  'CH', // Switzerland
+  'IS', // Iceland
+  'LI', // Liechtenstein
+  'NO', // Norway
+] as GTMConsentOptions['region'];
+
+const CCPARegions = [
+  'US'
+] as GTMConsentOptions['region'];
+
+// For clarity, all 3 defaults are explicitly set
+// here, even though technically this can be done with
+// GDPR and a default.
+
+const defaultConsentOptsGDPR: GTMConsentOptions = {
 	ad_storage: 'denied',
+	analytics_storage: 'denied',
+	functionality_storage: 'granted',
+	personalization_storage: 'granted',
+	security_storage: 'granted',
+  wait_for_update: 5000,
+  region: GDPRRegions,
+};
+
+const defaultConsentOptsCCPA: GTMConsentOptions = {
+	ad_storage: 'granted',
 	analytics_storage: 'granted',
 	functionality_storage: 'granted',
 	personalization_storage: 'granted',
 	security_storage: 'granted',
-	wait_for_update: 5000,
+  wait_for_update: 5000,
+  region: CCPARegions,
+};
+
+const defaultConsentOpts: GTMConsentOptions = {
+	ad_storage: 'granted',
+	analytics_storage: 'granted',
+	functionality_storage: 'granted',
+	personalization_storage: 'granted',
+	security_storage: 'granted',
+  wait_for_update: 5000,
 };
 
 window.dataLayer = window.dataLayer || [];
 
 function gtag() {
-	window.dataLayer.push(arguments);
+  window.dataLayer.push(arguments);
 }
 
 const gtmInit = () => {
+	gtag('consent', 'default', defaultConsentOptsGDPR);
+	gtag('consent', 'default', defaultConsentOptsCCPA);
 	gtag('consent', 'default', defaultConsentOpts);
 
 	const prefs = getTrackingPrefs();
@@ -31,4 +98,4 @@ const gtmInit = () => {
 	gtag('config', 'GTM-5QBVTK7');
 };
 
-export default gtmInit;
+  export default gtmInit;

--- a/block/src/utils/convert-prefs.ts
+++ b/block/src/utils/convert-prefs.ts
@@ -6,13 +6,54 @@ type Buckets = {
 	advertising: boolean;
 };
 
+type GDPRRegionType =
+  // European Member countries
+  'AT' | // Austria
+  'BE' | // Belgium
+  'BG' | // Bulgaria
+  'CY' | // Cyprus
+  'CZ' | // Czech Republic
+  'DE' | // Germany
+  'DK' | // Denmark
+  'EE' | // Estonia
+  'ES' | // Spain
+  'FI' | // Finland
+  'FR' | // France
+  'GR' | // Greece
+  'HR' | // Croatia
+  'HU' | // Hungary
+  'IE' | // Ireland
+  'IT' | // Italy
+  'LT' | // Lithuania
+  'LU' | // Luxembourg
+  'LV' | // Latvia
+  'MT' | // Malta
+  'NL' | // Netherlands
+  'PL' | // Poland
+  'PT' | // Portugal
+  'RO' | // Romania
+  'SE' | // Sweden
+  'SI' | // Slovenia
+  'SK' | // Slovakia
+  'GB' | // United Kingdom
+  // Single Market Countries that GDPR applies to
+  'CH' | // Switzerland
+  'IS' | // Iceland
+  'LI' | // Liechtenstein
+  'NO'; // Norway
+
+type PrivacyLawRegions = GDPRRegionType |
+  'US' // United States
+;
+
 type GTMConsentOptions = {
 	ad_storage: 'granted' | 'denied';
 	analytics_storage: 'granted' | 'denied';
 	functionality_storage: 'granted' | 'denied';
 	personalization_storage: 'granted' | 'denied';
 	security_storage: 'granted' | 'denied';
-	wait_for_update: number;
+  wait_for_update: number;
+  region?: PrivacyLawRegions[];
 };
 
 const convertBucketsToGTMOpts = (
@@ -37,4 +78,4 @@ const convertPrefsToGTMOpts = (prefs: TrackingPrefs) => {
 };
 
 export { convertBucketsToGTMOpts, convertPrefsToGTMOpts };
-export type { GTMConsentOptions };
+export type { GTMConsentOptions, GDPRRegionType };


### PR DESCRIPTION
# Overview

Goal is to set the regional consent defaults for GTM config.
