### PR TITLE
Refactor to include non-block theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@ This WordPress plugin is designed to implement the cookie banner and "do not sel
 ## Use
 
 1.  Add the plugin and activate
-2.  Place the "Privacy Tools Consent Banner" block in a template part used on all pages—i.e. your footer. 
-3.  Add the do-not-sell link to the same component as a normal link with the anchor `#do-not-sell-preferences`
+2.  Place the "Privacy Tools Consent Banner" block in a template part used on all pages—i.e. your footer.
+3.  Add the do-not-sell link to the same component as a normal link with the ID `#do-not-sell-preferences`.
+
+```
+<p id="do-not-sell-preferences" style="display: none;"><a href="#">Do not sell or share my personal information.</a></p>
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # WP Privacy Toolset
 
-This WordPress plugin is designed to implement the cookie banner and "do not sell" dialog from the wp-calypso project. It is designed to be used on a block theme.
+This WordPress plugin is designed to implement the cookie banner and "do not sell" dialog from the wp-calypso project.
 
 ## Use
 
-1.  Add the plugin and activate
-2.  Place the "Privacy Tools Consent Banner" block in a template part used on all pages—i.e. your footer.
-3.  Add the do-not-sell link to the same component as a normal link with the ID `#do-not-sell-preferences`.
+1. Add the plugin and activate.
+2. Place the "Privacy Tools Consent Banner" block in a template part used on all pages—i.e. your footer.
+   2a. If using a non-block theme, this will be automatically applied to the footer.
+3. Add the do-not-sell link to the same component as a normal link with the ID `#do-not-sell-preferences`.
 
-```
+```html
 <p id="do-not-sell-preferences" style="display: none;"><a href="#">Do not sell or share my personal information.</a></p>
 ```
 
 ## Development
 
-1.  `cd block`
-2.  `yarn`
-3.  `yarn start`
+1. `cd block`
+2. `yarn`
+3. `yarn start`

--- a/block/src/components/DoNotSellDialog/index.tsx
+++ b/block/src/components/DoNotSellDialog/index.tsx
@@ -37,7 +37,7 @@ const DoNotSellDialog = () => {
 
 	useEffect(() => {
 		const selector = document.querySelectorAll(
-			'[href$="#do-not-sell-preferences"]'
+			'#do-not-sell-preferences'
 		) as NodeListOf<HTMLElement>;
 
 		if (shouldSeeDoNotSell) {

--- a/privacy-toolset.php
+++ b/privacy-toolset.php
@@ -9,20 +9,59 @@
  * @package automattic-privacy-toolset
  */
 
-// TODO setup plugin class
-// TODO standardize function names
-// TODO add noscript GTM code in body
-// TODO better version than current time
+namespace Automattic\PrivacyToolset;
 
-function create_privacy_toolset_block() {
-  register_block_type(__DIR__ . '/block/build');
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
-add_action('init', 'create_privacy_toolset_block');
 
-function privacy_toolset_enqueue_styles() {
-  wp_enqueue_style(
-    'privacy-toolset',
-    __DIR__ . '/block/build/privacy-consent-banner.css?ver=' . time()
-  );
+class PrivacyToolset {
+  	/**
+     * Javascript built asset path.
+     *
+     * @var string
+     */
+    private $javascript_path = 'block/build/privacy-consent-banner.js';
+
+    /**
+     * CSS built asset path.
+     *
+     * @var string
+     */
+    private $css_path = 'block/build/privacy-consent-banner.css';
+
+    /**
+	   * Class constructor.
+	   */
+    public function __construct() {
+        // Register block for block themes and enqueue assets
+        add_action( 'init', [ $this, 'register_assets' ] );
+    }
+
+    public function register_assets() {
+        // Register block for block themes or manually enqueue javascript and insert footer element for non-block themes
+        if ( wp_is_block_theme() ) {
+            register_block_type( plugin_dir_path( __FILE__ ) . 'block/build' );
+        } else {
+            $this->enqueue_javascript();
+            add_action( 'wp_footer', [ $this, 'privacy_consent_footer' ] );
+        }
+        // Enqueue CSS for block/non-block themes
+        $this->enqueue_css();
+    }
+
+    public function privacy_consent_footer() {
+        echo '<div class="wp-block-privacy-tools-consent-banner"><div id="privacy-consent-banner"></div></div>';
+    }
+
+    private function enqueue_javascript() {
+        wp_enqueue_script( 'vip-cookie-banner-js', plugins_url( $this->javascript_path, __FILE__ ), array( 'react', 'react-dom', 'wp-components', 'wp-element', 'wp-i18n' ), '1.0.0', true);
+    }
+
+    private function enqueue_css() {
+        wp_enqueue_style( 'privacy-toolset-css', plugins_url( $this->css_path, __FILE__ ), [], '1.0.0' );
+    }
 }
-add_action('init', 'privacy_toolset_enqueue_styles');
+
+new PrivacyToolset();

--- a/privacy-toolset.php
+++ b/privacy-toolset.php
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class PrivacyToolset {
+
   	/**
      * Javascript built asset path.
      *


### PR DESCRIPTION
Hey team,

This is in regard to the open JIRA https://vipjira.atlassian.net/browse/VIPMW-296 and implementing the cookie banner on the documentation site https://docs.wpvip.com. 

The issue is that the documentation site is a non-block theme which this does not currently support. I've created a fork/PR of this plugin and made a simple workaround to enqueue the javascript and CSS file: https://github.com/wpcomvip/vip-wordpress-com/pull/1684

Rather than making a fork, I'd like to present an update to this plugin to add that support. I also added the plugin class and I'm open to any suggestions. I made a minor change to `DoNotSellDialog/index.tsx` so that it targets the `<p>` element to fix the uneven gap:

![](https://cdn-std.droplr.net/files/acc_1281363/m55lbJ)

It's subtle but my OCD can't not see it. 😆

With this change, the current markup in the footer on wpvip.com will need to be adjusted but is a quick fix:

```
<p id="do-not-sell-preferences" style="display: none;"><a href="#">Do not sell or share my personal information.</a></p>
```

This has been tested locally and on my test environment which you can test: https://dev.wrasada.com

Since there is some priority in getting this working on docs.wpvip.com, perhaps we start with reviewing these changes and getting it pushed and then updating in `vip-wordpress-com`.  And any big changes/suggestions we can work on over time.

I am a bit curious why the block implementation was used when `wp_footer` would remove a manual step and/or human error unless the block was decided to only allow on certain pages?