### PR TITLE
Fix critical npm alerts

### DIFF
--- a/block/package-lock.json
+++ b/block/package-lock.json
@@ -1271,21 +1271,106 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.22.8",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-			"integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.22.5",
-				"@babel/generator": "^7.22.7",
-				"@babel/helper-environment-visitor": "^7.22.5",
-				"@babel/helper-function-name": "^7.22.5",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.22.7",
-				"@babel/types": "^7.22.5",
+				"@babel/parser": "^7.23.0",
+				"@babel/types": "^7.23.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.22.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+					"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.22.13",
+						"chalk": "^2.4.2"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.23.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+					"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.23.0",
+						"@jridgewell/gen-mapping": "^0.3.2",
+						"@jridgewell/trace-mapping": "^0.3.17",
+						"jsesc": "^2.5.1"
+					}
+				},
+				"@babel/helper-environment-visitor": {
+					"version": "7.22.20",
+					"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+					"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+					"dev": true
+				},
+				"@babel/helper-function-name": {
+					"version": "7.23.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+					"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.22.15",
+						"@babel/types": "^7.23.0"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.22.20",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+					"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.22.20",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+					"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.22.20",
+						"chalk": "^2.4.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.23.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+					"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.22.15",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+					"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.22.13",
+						"@babel/parser": "^7.22.15",
+						"@babel/types": "^7.22.15"
+					}
+				},
+				"@babel/types": {
+					"version": "7.23.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+					"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-string-parser": "^7.22.5",
+						"@babel/helper-validator-identifier": "^7.22.20",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/types": {
@@ -4805,6 +4890,12 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.6.2",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
+					"integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
+					"dev": true
+				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5626,6 +5717,24 @@
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
+			}
+		},
+		"call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"requires": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"dependencies": {
+				"function-bind": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+					"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+					"dev": true
+				}
 			}
 		},
 		"callsites": {
@@ -6785,6 +6894,25 @@
 				}
 			}
 		},
+		"dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"requires": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"dependencies": {
+				"gopd": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+					"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+					"dev": true
+				}
+			}
+		},
 		"duplexer": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -6929,11 +7057,32 @@
 				"which-typed-array": "^1.1.9"
 			}
 		},
+		"es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true
+		},
+		"es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true
+		},
 		"es-module-lexer": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
 			"integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
 			"dev": true
+		},
+		"es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"dev": true,
+			"requires": {
+				"es-errors": "^1.3.0"
+			}
 		},
 		"es-set-tostringtag": {
 			"version": "2.0.1",
@@ -8113,14 +8262,75 @@
 			}
 		},
 		"form-data": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+			"integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
 			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.35"
+			},
+			"dependencies": {
+				"es-set-tostringtag": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+					"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+					"dev": true,
+					"requires": {
+						"es-errors": "^1.3.0",
+						"get-intrinsic": "^1.2.6",
+						"has-tostringtag": "^1.0.2",
+						"hasown": "^2.0.2"
+					}
+				},
+				"function-bind": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+					"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+					"dev": true
+				},
+				"get-intrinsic": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+					"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+					"dev": true,
+					"requires": {
+						"call-bind-apply-helpers": "^1.0.2",
+						"es-define-property": "^1.0.1",
+						"es-errors": "^1.3.0",
+						"es-object-atoms": "^1.1.1",
+						"function-bind": "^1.1.2",
+						"get-proto": "^1.0.1",
+						"gopd": "^1.2.0",
+						"has-symbols": "^1.1.0",
+						"hasown": "^2.0.2",
+						"math-intrinsics": "^1.1.0"
+					}
+				},
+				"gopd": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+					"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+					"dev": true
+				},
+				"has-symbols": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+					"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+					"dev": true
+				},
+				"has-tostringtag": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+					"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+					"dev": true,
+					"requires": {
+						"has-symbols": "^1.0.3"
+					}
+				}
 			}
 		},
 		"forwarded": {
@@ -8262,6 +8472,16 @@
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
+		},
+		"get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"requires": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			}
 		},
 		"get-stdin": {
 			"version": "9.0.0",
@@ -8482,6 +8702,23 @@
 			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.2"
+			}
+		},
+		"hasown": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.2"
+			},
+			"dependencies": {
+				"function-bind": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+					"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+					"dev": true
+				}
 			}
 		},
 		"header-case": {
@@ -11109,6 +11346,12 @@
 			"integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==",
 			"dev": true
 		},
+		"math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true
+		},
 		"mathml-tag-names": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -12480,12 +12723,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true
-		},
-		"prettier": {
-			"version": "npm:wp-prettier@2.6.2",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
-			"integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {


### PR DESCRIPTION
## Summary
- Update the legacy npm v1 lockfile without converting it.
- Bump vulnerable transitive `@babel/traverse` and `form-data` versions used by the block package.

## Testing
- `npx npm@6 ci --ignore-scripts`
- `npx npm@6 audit --json --package-lock-only` (`critical: 0`)
- `npx npm@6 ls @babel/traverse form-data --all`
- `npx npm@6 run build`
- `npx npm@6 run check-engines`
- `npx npm@6 run check-licenses` (passes with peer dependency warnings)
- `npx npm@6 run lint:js` (fails on untouched lint debt: 490 errors, 2 warnings)
- `npx npm@6 run lint:css` (fails on untouched stylelint debt: 38 errors)
- `npx npm@6 run test:unit` (fails: no tests found)